### PR TITLE
Use google hosted font, minor resume update

### DIFF
--- a/app/dist/index.html
+++ b/app/dist/index.html
@@ -3,6 +3,7 @@
   <head>
     <link rel="icon" type="image/png" href="https://i.imgur.com/l4JNaff.png">
     <link rel="stylesheet/less" type="text/css" href="style.less" />
+    <link href="https://fonts.googleapis.com/css?family=Inconsolata:400,700" rel="stylesheet">
     <script src="//cdnjs.cloudflare.com/ajax/libs/less.js/3.7.0/less.min.js" ></script>
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <title>Stephen Costa</title>

--- a/app/dist/style.less
+++ b/app/dist/style.less
@@ -85,7 +85,7 @@ footer {
 }
 
 .hello {
-    font-family: Consolas;
+    font-family: 'Inconsolata', monospace, bold;
     color: green;
 }
 

--- a/app/src/components/pages/ResumePage.jsx
+++ b/app/src/components/pages/ResumePage.jsx
@@ -6,7 +6,7 @@ class ResumePage extends Component {
         return (
           <div class='primaryContainer'>
             <h3>Resume</h3>
-            <iframe width="800" height="900" className="pdfViewer" src="https://www.docdroid.net/OnjeTL0/resume2018.pdf" frameborder="0" allowtransparency allowfullscreen></iframe>
+            <iframe width="800" height="900" className="pdfViewer" src="https://www.docdroid.net/CWc5gro/resume2018.pdf" frameborder="0" allowtransparency allowfullscreen></iframe>
           </div>
         )
     }


### PR DESCRIPTION
Title says it all. Font for typewriter (`Hello World!` on homepage) was only working on windows/chrome I believe. Changed the font to be hosted by Google, so any OS/browser should be able to access it (previously it was just included in certain browsers). 
I used BrowserShots to verify correct behavior, because I am too cheap to pay for BrowserStack.