### PR TITLE
Remove lodash

### DIFF
--- a/app/src/components/TableComponent/Table.jsx
+++ b/app/src/components/TableComponent/Table.jsx
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import _ from 'lodash';
 import DetailRow from './DetailRow';
 import ExpandButton from './ExpandButton';
 import { projectNames } from './tableConstants';
@@ -75,7 +74,7 @@ class Table extends Component {
   }
 
   isRowExpanded(rowId) {
-    return _.includes(this.state.expandedRowIds, rowId);
+    return this.state.expandedRowIds.indexOf(rowId) !== -1;
   }
 
   getDetailsRow(rowNum, rowId, isExpanded) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -441,7 +441,7 @@
         "convert-source-map": "1.5.1",
         "debug": "2.6.9",
         "json5": "0.5.1",
-        "lodash": "4.17.10",
+        "lodash": ">=4.17.11",
         "minimatch": "3.0.4",
         "path-is-absolute": "1.0.1",
         "private": "0.1.8",
@@ -459,7 +459,7 @@
         "babel-types": "6.26.0",
         "detect-indent": "4.0.0",
         "jsesc": "1.3.0",
-        "lodash": "4.17.10",
+        "lodash": ">=4.17.11",
         "source-map": "0.5.7",
         "trim-right": "1.0.1"
       }
@@ -493,7 +493,7 @@
         "babel-helper-function-name": "6.24.1",
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "lodash": ">=4.17.11"
       }
     },
     "babel-helper-function-name": {
@@ -542,7 +542,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "lodash": ">=4.17.11"
       }
     },
     "babel-helper-replace-supers": {
@@ -628,7 +628,7 @@
         "babel-template": "6.26.0",
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
-        "lodash": "4.17.10"
+        "lodash": ">=4.17.11"
       }
     },
     "babel-plugin-transform-es2015-classes": {
@@ -938,7 +938,7 @@
         "babel-runtime": "6.26.0",
         "core-js": "2.5.7",
         "home-or-tmp": "2.0.0",
-        "lodash": "4.17.10",
+        "lodash": ">=4.17.11",
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18"
       },
@@ -975,7 +975,7 @@
         "babel-traverse": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "lodash": "4.17.10"
+        "lodash": ">=4.17.11"
       }
     },
     "babel-traverse": {
@@ -991,7 +991,7 @@
         "debug": "2.6.9",
         "globals": "9.18.0",
         "invariant": "2.2.4",
-        "lodash": "4.17.10"
+        "lodash": ">=4.17.11"
       }
     },
     "babel-types": {
@@ -1001,7 +1001,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
-        "lodash": "4.17.10",
+        "lodash": ">=4.17.11",
         "to-fast-properties": "1.0.3"
       }
     },
@@ -3110,7 +3110,7 @@
         "cli-width": "2.2.0",
         "external-editor": "3.0.0",
         "figures": "2.0.0",
-        "lodash": "4.17.10",
+        "lodash": ">=4.17.11",
         "mute-stream": "0.0.7",
         "run-async": "2.3.0",
         "rxjs": "6.2.1",


### PR DESCRIPTION
Removing use of lodash due to a security vulnerability. It's also unnecessary to use it in the first place.